### PR TITLE
Wrap setting of alternate buffer in bufexists

### DIFF
--- a/plugin/broot.vim
+++ b/plugin/broot.vim
@@ -64,7 +64,9 @@ function! g:OnExitNvim(job_id, code, event)
         execute 'buffer ' . s:current_buffer
         let @# = s:alternate_buffer
     else
-        let @# = s:current_buffer
+        if bufexists(s:current_buffer)
+            let @# = s:current_buffer
+        endif
     endif
     if a:code == 0 && bufexists(s:terminal_buffer)
         execute 'bwipeout! ' . s:terminal_buffer
@@ -98,7 +100,9 @@ function! g:ReadBrootOutPath(job, exit)
             endif
             let @# = s:alternate_buffer
         else
-            let @# = s:current_buffer
+            if bufexists(s:current_buffer)
+                let @# = s:current_buffer
+            endif
         endif
         if bufexists(l:buffer_number)
             silent execute 'bwipeout! ' . l:buffer_number


### PR DESCRIPTION
If you use `:Broot` from an unmodified no-name buffer (i.e., when `vim` is first opened), it throws an error when trying to update the alternate buffer register:

```
E86: Buffer does not exist
```

https://user-images.githubusercontent.com/739304/150816820-66c91a1c-318a-45e3-8053-b71d355bc2aa.mov

This PR wraps the setting of that register in a `bufexists` check and avoids the error.

Perhaps there's a better approach that allows the no-name buffer to be represented as the alternate buffer, but I'm not sure how to do that.