### PR TITLE
Move expand sfile call to top level of script

### DIFF
--- a/plugin/broot.vim
+++ b/plugin/broot.vim
@@ -88,16 +88,19 @@ function! s:CreateConfig(env)
 
     let l:config.env.broot = s:GetBrootVersion(l:config.settings.broot_command)
 
-    let l:broot_vim_conf_path = fnamemodify(resolve(expand("<sfile>:p")), ":h:h") . "/broot.toml"
-    call writefile(l:config.settings.broot_vim_conf, l:broot_vim_conf_path)
+    call writefile(l:config.settings.broot_vim_conf, s:broot_vim_conf_path)
 
-    let l:broot_conf_paths = l:config.settings.broot_default_conf_path . ";" . l:broot_vim_conf_path
+    let l:broot_conf_paths = l:config.settings.broot_default_conf_path . ";" . s:broot_vim_conf_path
     let l:config.broot_exec = l:config.settings.broot_command . " --conf '" . l:broot_conf_paths . "'"
 
     return l:config
 endfunction
 
 let s:env = s:CreateEnv()
+
+" expand("<sfile>:p") must be called at the top level or it returns the stack
+" trace not the relative path
+let s:broot_vim_conf_path = fnamemodify(resolve(expand("<sfile>:p")), ":h:h") . "/broot.toml"
 
 try
     if !s:IsCompatible(s:env)


### PR DESCRIPTION
HI, here is a quick PR to fix issue https://github.com/lstwn/broot.vim/issues/7. Fixed it in my fork anyway, so if you want to merge feel free!

Per my note on the issue, this fixes bug where call to `expand("<sfile>:p")` inside function does not return the relative path. This leads to the config file being created in an arbitrary location in the filesystem with potentially erroneous results.

Cheers,
Brendan
