### PR TITLE
Switch load order of broot conf paths

### DIFF
--- a/plugin/broot.vim
+++ b/plugin/broot.vim
@@ -90,7 +90,9 @@ function! s:CreateConfig(env)
 
     call writefile(l:config.settings.broot_vim_conf, s:broot_vim_conf_path)
 
-    let l:broot_conf_paths = l:config.settings.broot_default_conf_path . ";" . s:broot_vim_conf_path
+    " load vim-soecific conf first as broot appends verbs, ensuring that
+    " broot_vim_conf verbs override those in default config
+    let l:broot_conf_paths = s:broot_vim_conf_path . ";" . l:config.settings.broot_default_conf_path
     let l:config.broot_exec = l:config.settings.broot_command . " --conf '" . l:broot_conf_paths . "'"
 
     return l:config

--- a/plugin/broot.vim
+++ b/plugin/broot.vim
@@ -90,7 +90,7 @@ function! s:CreateConfig(env)
 
     call writefile(l:config.settings.broot_vim_conf, s:broot_vim_conf_path)
 
-    " load vim-soecific conf first as broot appends verbs, ensuring that
+    " load vim-specific conf first as broot appends verbs, ensuring that
     " broot_vim_conf verbs override those in default config
     let l:broot_conf_paths = s:broot_vim_conf_path . ";" . l:config.settings.broot_default_conf_path
     let l:config.broot_exec = l:config.settings.broot_command . " --conf '" . l:broot_conf_paths . "'"
@@ -119,7 +119,7 @@ function! g:BrootLogConfig()
     return json_encode(s:config)
 endfunction
 
-" type BrootSession = Record<JobId (nvim) | BufNr (vim), { 
+" type BrootSession = Record<JobId (nvim) | BufNr (vim), {
 "   out_file: string,
 "   terminal_buffer: int,
 "   current_buffer: int,


### PR DESCRIPTION
Hi there, me again!

Here is a quick unsolicited PR for an issue I noticed while fixing some configs. Broot appends rather than overrides verbs, then appears to take the first matching keycode. So for instance if the user has defined a custom verb for `Enter` then the broot_vim `echo +{line} {file} won't end up getting used.

I flipped the order of the config imports in this PR to fix. This way, anything in `broot_vim_conf` gets loaded first and has priority.

Cheers,
Brendan